### PR TITLE
Fix: Handle orphaned snapshot files from removed plans gracefully

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,16 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(vendor/bin/phpunit:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr view:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/src/Commands/Concerns/HasCommandHelpers.php
+++ b/src/Commands/Concerns/HasCommandHelpers.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ZiffMedia\LaravelMysqlSnapshots\Commands\Concerns;
+
+use ZiffMedia\LaravelMysqlSnapshots\SnapshotPlan;
+
+trait HasCommandHelpers
+{
+    protected function warnAboutUnacceptedFiles(): void
+    {
+        if (count(SnapshotPlan::$unacceptedFiles) > 0) {
+            $this->newLine();
+            $this->warn('Warning: Found ' . count(SnapshotPlan::$unacceptedFiles) . ' file(s) in the archive that do not match any configured plan:');
+
+            foreach (SnapshotPlan::$unacceptedFiles as $unacceptedFile) {
+                $this->line("  {$unacceptedFile}");
+            }
+
+            $this->line('');
+            $this->line('These files may be from removed plans and can be safely deleted if no longer needed.');
+        }
+    }
+}

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -6,11 +6,14 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use ZiffMedia\LaravelMysqlSnapshots\Commands\Concerns\HasCommandHelpers;
 use ZiffMedia\LaravelMysqlSnapshots\Snapshot;
 use ZiffMedia\LaravelMysqlSnapshots\SnapshotPlan;
 
 class ListCommand extends Command
 {
+    use HasCommandHelpers;
+
     protected $signature = <<<'EOS'
         mysql-snapshots:list
         {plan? : The Plan name, will default to the first one listed under "plans"}
@@ -69,18 +72,7 @@ class ListCommand extends Command
             }
         }
 
-        // Warn about unaccepted files
-        if (count(SnapshotPlan::$unacceptedFiles) > 0) {
-            $this->newLine();
-            $this->warn('Warning: Found ' . count(SnapshotPlan::$unacceptedFiles) . ' file(s) in the archive that do not match any configured plan:');
-
-            foreach (SnapshotPlan::$unacceptedFiles as $unacceptedFile) {
-                $this->line("  {$unacceptedFile}");
-            }
-
-            $this->line('');
-            $this->line('These files may be from removed plans and can be safely deleted if no longer needed.');
-        }
+        $this->warnAboutUnacceptedFiles();
 
         $this->newLine();
     }

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -69,6 +69,19 @@ class ListCommand extends Command
             }
         }
 
+        // Warn about unaccepted files
+        if (count(SnapshotPlan::$unacceptedFiles) > 0) {
+            $this->newLine();
+            $this->warn('Warning: Found ' . count(SnapshotPlan::$unacceptedFiles) . ' file(s) in the archive that do not match any configured plan:');
+
+            foreach (SnapshotPlan::$unacceptedFiles as $unacceptedFile) {
+                $this->line("  {$unacceptedFile}");
+            }
+
+            $this->line('');
+            $this->line('These files may be from removed plans and can be safely deleted if no longer needed.');
+        }
+
         $this->newLine();
     }
 }

--- a/src/Commands/LoadCommand.php
+++ b/src/Commands/LoadCommand.php
@@ -3,11 +3,14 @@
 namespace ZiffMedia\LaravelMysqlSnapshots\Commands;
 
 use Illuminate\Console\Command;
+use ZiffMedia\LaravelMysqlSnapshots\Commands\Concerns\HasCommandHelpers;
 use ZiffMedia\LaravelMysqlSnapshots\Snapshot;
 use ZiffMedia\LaravelMysqlSnapshots\SnapshotPlan;
 
 class LoadCommand extends Command
 {
+    use HasCommandHelpers;
+
     protected $signature = <<<'EOS'
         mysql-snapshots:load
         {plan? : The Plan name, will default to the first one listed under "plans"}
@@ -95,17 +98,6 @@ class LoadCommand extends Command
             }
         }
 
-        // Warn about unaccepted files
-        if (count(SnapshotPlan::$unacceptedFiles) > 0) {
-            $this->newLine();
-            $this->warn('Warning: Found ' . count(SnapshotPlan::$unacceptedFiles) . ' file(s) in the archive that do not match any configured plan:');
-
-            foreach (SnapshotPlan::$unacceptedFiles as $unacceptedFile) {
-                $this->line("  {$unacceptedFile}");
-            }
-
-            $this->line('');
-            $this->line('These files may be from removed plans and can be safely deleted if no longer needed.');
-        }
+        $this->warnAboutUnacceptedFiles();
     }
 }

--- a/src/Commands/LoadCommand.php
+++ b/src/Commands/LoadCommand.php
@@ -94,5 +94,18 @@ class LoadCommand extends Command
                 $this->line("  $clearedFile");
             }
         }
+
+        // Warn about unaccepted files
+        if (count(SnapshotPlan::$unacceptedFiles) > 0) {
+            $this->newLine();
+            $this->warn('Warning: Found ' . count(SnapshotPlan::$unacceptedFiles) . ' file(s) in the archive that do not match any configured plan:');
+
+            foreach (SnapshotPlan::$unacceptedFiles as $unacceptedFile) {
+                $this->line("  {$unacceptedFile}");
+            }
+
+            $this->line('');
+            $this->line('These files may be from removed plans and can be safely deleted if no longer needed.');
+        }
     }
 }

--- a/src/SnapshotPlan.php
+++ b/src/SnapshotPlan.php
@@ -287,7 +287,13 @@ class SnapshotPlan
             $fileDatePart = $fileName->betweenFirst($this->fileTemplateParts['prefix'], $this->fileTemplateParts['postfix']);
         }
 
-        return Carbon::createFromFormat($this->fileTemplateParts['date_format'] . '|', (string) $fileDatePart);
+        try {
+            return Carbon::createFromFormat($this->fileTemplateParts['date_format'] . '|', (string) $fileDatePart);
+        } catch (\Exception $e) {
+            // If Carbon cannot parse the date format (e.g., file from a removed plan with different naming),
+            // return false to indicate this file doesn't match this plan's pattern
+            return false;
+        }
     }
 
     public function accept(string $archiveFileName)

--- a/src/SnapshotPlan.php
+++ b/src/SnapshotPlan.php
@@ -3,6 +3,7 @@
 namespace ZiffMedia\LaravelMysqlSnapshots;
 
 use Carbon\Carbon;
+use Exception;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -289,7 +290,7 @@ class SnapshotPlan
 
         try {
             return Carbon::createFromFormat($this->fileTemplateParts['date_format'] . '|', (string) $fileDatePart);
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             // If Carbon cannot parse the date format (e.g., file from a removed plan with different naming),
             // return false to indicate this file doesn't match this plan's pattern
             return false;

--- a/tests/SnapshotPlanTest.php
+++ b/tests/SnapshotPlanTest.php
@@ -155,7 +155,7 @@ class SnapshotPlanTest extends TestCase
         new SnapshotPlan('daily', $config);
     }
 
-    public function testSnapshotPlanHandlesOrphanedFilesFromRemovedPlans()
+    public function test_snapshot_plan_handles_orphaned_files_from_removed_plans()
     {
         // Setup: Create snapshot files that match different plan patterns
         $archiveDisk = Storage::disk(config('mysql-snapshots.filesystem.archive_disk'));

--- a/tests/SnapshotPlanTest.php
+++ b/tests/SnapshotPlanTest.php
@@ -22,6 +22,9 @@ class SnapshotPlanTest extends TestCase
         config()->set('mysql-snapshots.utilities.mysqldump', __DIR__ . '/fixtures/fakemysqldump');
 
         $this->cleanupFiles();
+
+        // Reset static unacceptedFiles array
+        SnapshotPlan::$unacceptedFiles = [];
     }
 
     protected function tearDown(): void
@@ -150,6 +153,42 @@ class SnapshotPlanTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('schema_only_tables that are configured must appear in tables as well');
         new SnapshotPlan('daily', $config);
+    }
+
+    public function testSnapshotPlanHandlesOrphanedFilesFromRemovedPlans()
+    {
+        // Setup: Create snapshot files that match different plan patterns
+        $archiveDisk = Storage::disk(config('mysql-snapshots.filesystem.archive_disk'));
+        $archivePath = config('mysql-snapshots.filesystem.archive_path');
+
+        // Create a file that matches a "daily-v8" plan pattern (which we'll pretend was removed)
+        $orphanedFile = $archivePath . '/mysql-snapshot-daily-v8-20240913.sql.gz';
+        $archiveDisk->put($orphanedFile, 'fake snapshot content');
+
+        // Create a file that matches our current "daily" plan pattern
+        $validFile = $archivePath . '/mysql-snapshot-daily-20240913.sql.gz';
+        $archiveDisk->put($validFile, 'fake snapshot content');
+
+        // Configure only the "daily" plan (simulating that "daily-v8" was removed)
+        config()->set('mysql-snapshots.plans', [
+            'daily' => $this->defaultDailyConfig(),
+        ]);
+
+        // This should not throw an exception despite the orphaned file
+        $plans = SnapshotPlan::all();
+
+        // Assert that we got our plan
+        $this->assertCount(1, $plans);
+        $dailyPlan = $plans->first();
+        $this->assertEquals('daily', $dailyPlan->name);
+
+        // Assert that only the matching file was accepted
+        $this->assertCount(1, $dailyPlan->snapshots);
+        $this->assertEquals('mysql-snapshot-daily-20240913.sql.gz', $dailyPlan->snapshots->first()->fileName);
+
+        // Assert that the orphaned file was tracked as unaccepted
+        $this->assertCount(1, SnapshotPlan::$unacceptedFiles);
+        $this->assertStringContainsString('mysql-snapshot-daily-v8-20240913.sql.gz', SnapshotPlan::$unacceptedFiles[0]);
     }
 
     protected function defaultDailyConfig(): array


### PR DESCRIPTION
## Summary
- Fixes #5
- Adds graceful handling of snapshot files from removed plans
- Prevents Carbon InvalidFormatException when orphaned files are encountered

## Changes
- Modified `SnapshotPlan::matchFileAndDate()` to catch Carbon parsing exceptions and return `false` instead of throwing
- Added test `testSnapshotPlanHandlesOrphanedFilesFromRemovedPlans()` to verify the fix
- Added cleanup of static `$unacceptedFiles` array in test setup

## Test Plan
- Added unit test that reproduces the issue and verifies the fix
- All existing tests continue to pass
- Orphaned files are now properly tracked in `SnapshotPlan::$unacceptedFiles` array

## Scenario Reproduced
1. Create snapshot files for plan "daily-v8" 
2. Remove "daily-v8" from config
3. Load snapshot from "daily" plan
4. Previously: Carbon exception thrown
5. Now: Gracefully handles orphaned files, tracks them as unaccepted